### PR TITLE
Stubbed replicas/partitions for initial PjRt work

### DIFF
--- a/build_tools/sync.py
+++ b/build_tools/sync.py
@@ -53,6 +53,7 @@ def sync_nightly():
   sync_iree_runtime_submodules(iree_path)
   jax_path = checkout_repo("jax", "https://github.com/google/jax.git")
   tf_commit = probe_jax_tensorflow_commit(jax_path)
+  tf_commit = "HEAD" # TODO Disable once JAX syncs to a newer TF version
   log(f"Jax is synced to tensorflow commit {tf_commit}")
   tf_path = checkout_repo("tensorflow",
                           "https://github.com/tensorflow/tensorflow.git",

--- a/iree/integrations/pjrt/common/api_impl.cc
+++ b/iree/integrations/pjrt/common/api_impl.cc
@@ -1210,6 +1210,18 @@ void ExecutableImage::BindApi(PJRT_Api* api) {
     args->num_outputs = exec->result_count;
     return nullptr;
   };
+  api->PJRT_Executable_NumPartitions =
+      +[](PJRT_Executable_NumPartitions_Args* args) -> PJRT_Error* {
+    // This should be updated once iree supports partitioning.
+    args->num_partitions = 1;
+    return nullptr;
+  };
+  api->PJRT_Executable_NumReplicas =
+      +[](PJRT_Executable_NumReplicas_Args* args) -> PJRT_Error* {
+    // This should be updated once iree supports replicas.
+    args->num_replicas = 1;
+    return nullptr;
+  };
   api->PJRT_Executable_Serialize =
       +[](PJRT_Executable_Serialize_Args* args) -> PJRT_Error* {
     return MakeError(iree_make_status(IREE_STATUS_UNIMPLEMENTED,


### PR DESCRIPTION
Current version crashes due to incompatibility with the current binding API. Specifically missing
replicas / partition count querying. Added and set to `1` to avoid crashing.