### PR TITLE
Update for change to vm type descriptor naming.

### DIFF
--- a/iree/integrations/pjrt/common/api_impl.cc
+++ b/iree/integrations/pjrt/common/api_impl.cc
@@ -1514,7 +1514,7 @@ iree_status_t LoadedExecutableInstance::BatchExecute(
     for (size_t i = 0; i < inv.res_exe->result_count; ++i) {
       iree::vm::ref<iree_hal_buffer_view_t> ret_buffer_view =
           retain_ref((iree_hal_buffer_view_t*)iree_vm_list_get_ref_deref(
-              inv.outputs.get(), i, iree_hal_buffer_view_get_descriptor()));
+              inv.outputs.get(), i, &iree_hal_buffer_view_descriptor));
       // This should not be possible so just hard-assert.
       IREE_ASSERT_ARGUMENT(ret_buffer_view);
       auto result_buffer = std::make_unique<BufferInstance>(


### PR DESCRIPTION
Fixes for this commit upstream: https://github.com/openxla/iree/commit/784db04adc74c5bfa5a434f1e686a0ff69906e8b