### PR TITLE
Migrate dependency from tensorflow to openxla/xla

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,10 +7,6 @@
 import %workspace%/build_tools/bazel/iree_pjrt.bazelrc
 import %workspace%/env.bazelrc
 
-# Required by OpenXLA
-# https://github.com/openxla/xla/issues/1323
-build --nocheck_visibility
-
 # Import the main IREE bazel configuration.
 import %workspace%/external/iree/build_tools/bazel/iree.bazelrc
 try-import %workspace%/external/iree/configured.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,10 @@
 import %workspace%/build_tools/bazel/iree_pjrt.bazelrc
 import %workspace%/env.bazelrc
 
+# Required by OpenXLA
+# https://github.com/openxla/xla/issues/1323
+build --nocheck_visibility
+
 # Import the main IREE bazel configuration.
 import %workspace%/external/iree/build_tools/bazel/iree.bazelrc
 try-import %workspace%/external/iree/configured.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ bazel-*
 env.bazelrc
 external/
 .vscode/
+__pycache__/
 user.bazelrc

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Build a compatible jaxlib:
 # working on it :/
 cd external/jax
 python build/build.py \
-  --bazel_options=--override_repository=org_tensorflow=$PWD/../tensorflow \
+  --bazel_options=--override_repository=xla=$PWD/../xla \
   --enable_tpu
 pip install dist/*.whl --force-reinstall
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Adds a local dependency on xla."""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
 local_repository(
     name = "xla",
     path = "external/xla",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,13 +3,13 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-"""Adds a local dependency on tensorflow."""
+"""Adds a local dependency on xla."""
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 local_repository(
-    name = "org_tensorflow",
-    path = "external/tensorflow",
+    name = "xla",
+    path = "external/xla",
 )
 
 local_repository(
@@ -17,22 +17,26 @@ local_repository(
     path = "external/iree",
 )
 
-# Import all of the tensorflow dependencies.
-load("@org_tensorflow//tensorflow:workspace3.bzl", "tf_workspace3")
+# Import all of the xla dependencies.
+load("@xla//:workspace4.bzl", "xla_workspace4")
 
-tf_workspace3()
+xla_workspace4()
 
-load("@org_tensorflow//tensorflow:workspace2.bzl", "tf_workspace2")
+load("@xla//:workspace3.bzl", "xla_workspace3")
 
-tf_workspace2()
+xla_workspace3()
 
-load("@org_tensorflow//tensorflow:workspace1.bzl", "tf_workspace1")
+load("@xla//:workspace2.bzl", "xla_workspace2")
 
-tf_workspace1()
+xla_workspace2()
 
-load("@org_tensorflow//tensorflow:workspace0.bzl", "tf_workspace0")
+load("@xla//:workspace1.bzl", "xla_workspace1")
 
-tf_workspace0()
+xla_workspace1()
+
+load("@xla//:workspace0.bzl", "xla_workspace0")
+
+xla_workspace0()
 
 # Setup IREE dependencies.
 load("@iree_core//build_tools/bazel:workspace.bzl", "configure_iree_submodule_deps", "configure_iree_cuda_deps")

--- a/build_tools/bazel/iree_pjrt.bazelrc
+++ b/build_tools/bazel/iree_pjrt.bazelrc
@@ -14,6 +14,10 @@
 build --copt="-fvisibility=hidden"
 build --copt="-fno-exceptions"
 
+# Required by OpenXLA
+# https://github.com/openxla/xla/issues/1323
+build --nocheck_visibility
+
 ###############################################################################
 # Configurations affecting the build.
 ###############################################################################

--- a/build_tools/sync.py
+++ b/build_tools/sync.py
@@ -53,9 +53,9 @@ def sync_nightly():
   sync_iree_runtime_submodules(iree_path)
   jax_path = checkout_repo("jax", "https://github.com/google/jax.git")
   xla_commit = probe_jax_xla_commit(jax_path)
-  log(f"Jax is synced to tensorflow commit {xla_commit}")
+  log(f"Jax is synced to xla commit {xla_commit}")
   xla_path = checkout_repo("xla",
-                          "https://github.com/xla/xla.git",
+                          "https://github.com/openxla/xla.git",
                           commit=xla_commit)
   write_env(iree_compiler_dylib=dylib_path)
 
@@ -161,7 +161,7 @@ def probe_jax_xla_commit(jax_path) -> str:
       "https://github.com/openxla/xla/archive/([0-9a-f]+).tar.gz",
       contents):
     return m[1]
-  raise ValueError(f"Unable to find tensorflow commit hash in {jax_path}")
+  raise ValueError(f"Unable to find xla commit hash in {jax_path}")
 
 
 def sync_iree_runtime_submodules(iree_path: Path):

--- a/build_tools/sync.py
+++ b/build_tools/sync.py
@@ -52,12 +52,11 @@ def sync_nightly():
                             commit=iree_commit)
   sync_iree_runtime_submodules(iree_path)
   jax_path = checkout_repo("jax", "https://github.com/google/jax.git")
-  tf_commit = probe_jax_tensorflow_commit(jax_path)
-  tf_commit = "HEAD" # TODO Disable once JAX syncs to a newer TF version
-  log(f"Jax is synced to tensorflow commit {tf_commit}")
-  tf_path = checkout_repo("tensorflow",
-                          "https://github.com/tensorflow/tensorflow.git",
-                          commit=tf_commit)
+  xla_commit = probe_jax_xla_commit(jax_path)
+  log(f"Jax is synced to tensorflow commit {xla_commit}")
+  xla_path = checkout_repo("xla",
+                          "https://github.com/xla/xla.git",
+                          commit=xla_commit)
   write_env(iree_compiler_dylib=dylib_path)
 
 
@@ -155,11 +154,11 @@ def probe_iree_compiler_dylib() -> str:
   raise ValueError(f"Could not find {dylib_basename} in {paths}")
 
 
-def probe_jax_tensorflow_commit(jax_path) -> str:
+def probe_jax_xla_commit(jax_path) -> str:
   with open(jax_path / "WORKSPACE", "rt") as f:
     contents = f.read()
   for m in re.finditer(
-      "https://github.com/tensorflow/tensorflow/archive/([0-9a-f]+).tar.gz",
+      "https://github.com/openxla/xla/archive/([0-9a-f]+).tar.gz",
       contents):
     return m[1]
   raise ValueError(f"Unable to find tensorflow commit hash in {jax_path}")

--- a/iree/integrations/pjrt/common/BUILD
+++ b/iree/integrations/pjrt/common/BUILD
@@ -32,8 +32,8 @@ iree_pjrt_cc_library(
         "@iree_core//runtime/src/iree/modules/hal",
         "@iree_core//runtime/src/iree/vm",
         "@iree_core//runtime/src/iree/vm/bytecode:module",
-        "@org_tensorflow//tensorflow/compiler/xla:shape_util",
-        "@org_tensorflow//tensorflow/compiler/xla/pjrt/c:pjrt_c_api_hdrs",
+        "@xla//xla:shape_util",
+        "@xla//xla/pjrt/c:pjrt_c_api_hdrs",
     ],
 )
 

--- a/iree/integrations/pjrt/common/api_impl.h
+++ b/iree/integrations/pjrt/common/api_impl.h
@@ -20,8 +20,8 @@
 #include "iree/modules/hal/module.h"
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode/module.h"
-#include "tensorflow/compiler/xla/pjrt/c/pjrt_c_api.h"
-#include "tensorflow/compiler/xla/shape_util.h"
+#include "xla/pjrt/c/pjrt_c_api.h"
+#include "xla/shape_util.h"
 
 namespace iree::pjrt {
 

--- a/iree/integrations/pjrt/common/dylib_entry_point.cc.inc
+++ b/iree/integrations/pjrt/common/dylib_entry_point.cc.inc
@@ -13,7 +13,7 @@
 //#include "iree/vm/api.h"
 //#include "iree/integrations/pjrt/common/pjrt_plugin_defs.h"
 //#include "iree/integrations/pjrt/common/pjrt_plugin_impl.h"
-#include "tensorflow/compiler/xla/pjrt/c/pjrt_c_api.h"
+#include "xla/pjrt/c/pjrt_c_api.h"
 
 #if (defined(_WIN32) || defined(__CYGWIN__)) && \
     !defined(PJRT_PLUGIN_ENABLE_WINDOWS_DLL_DECLSPEC)


### PR DESCRIPTION
JAX no longer depends on the TensorFlow repo and has migrated to github.com/openxla/xla. We should do the same. This includes update the repo-sync script, corrects the dependancies and addresses the visibility failure due to JAX referencing libraries that it does not technically have visibility to access.