### PR TITLE
Support degenerate HostToBuffer cases

### DIFF
--- a/.github/workflows/build_smoketest.yml
+++ b/.github/workflows/build_smoketest.yml
@@ -53,8 +53,13 @@ jobs:
         run: |
           bazel build iree/integrations/pjrt/cpu/...
 
+      - name: "Run Unittests"
+        run: |
+          bazel test iree/integrations/pjrt/common/...
+
       - name: "Test CPU plugin"
         run: |
           source .env.sh
           # TODO: We should be pinning/rolling a jaxlib nightly version.
           JAX_PLATFORMS=iree_cpu python test/test_simple.py
+          JAX_PLATFORMS=iree_cpu python test/test_degenerate.py

--- a/iree/integrations/pjrt/common/BUILD
+++ b/iree/integrations/pjrt/common/BUILD
@@ -12,6 +12,29 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+cc_library(
+    name = "tensor_utils",
+    srcs = [
+        "tensor_utils.cc",
+    ],
+    hdrs = [
+        "tensor_utils.h",
+    ],
+)
+
+cc_test(
+    name = "tensor_utils_test",
+    srcs = [
+        "tensor_utils_test.cc",
+    ],
+    linkstatic = True,
+    deps = [
+        ":tensor_utils",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ]
+)
+
 iree_pjrt_cc_library(
     name = "impl",
     srcs = [
@@ -26,6 +49,7 @@ iree_pjrt_cc_library(
     deps = [
         ":compiler",
         ":debugging",
+        ":tensor_utils",
         "@iree_core//runtime/src/iree/base",
         "@iree_core//runtime/src/iree/base:tracing",
         "@iree_core//runtime/src/iree/hal",

--- a/iree/integrations/pjrt/common/api_impl.cc
+++ b/iree/integrations/pjrt/common/api_impl.cc
@@ -11,6 +11,7 @@
 
 #include "iree/base/tracing.h"
 #include "iree/hal/api.h"
+#include "iree/integrations/pjrt/common/tensor_utils.h"
 
 using iree::vm::retain_ref;
 
@@ -677,27 +678,8 @@ iree_status_t DeviceInstance::HostBufferToDevice(
   iree_device_size_t element_type_byte_size =
       iree_hal_element_dense_byte_count(element_type);
 
-  // Handle strided layouts.
-  bool dense_row_major_layout = true;
-  if (byte_strides && num_dims > 0) {
-    int64_t stride = element_type_byte_size;
-    for (int64_t i = num_dims - 1; i >= 0; --i) {
-      if (byte_strides[i] != stride) {
-        dense_row_major_layout = false;
-        break;
-      }
-      stride *= dims[i];
-    }
-  }
-  if (!dense_row_major_layout) {
-    // TODO: Compile a transpose program and invoke that to load the
-    // array.
-    return iree_make_status(
-        IREE_STATUS_UNIMPLEMENTED,
-        "only dense, row-major layouts currently supported");
-  }
-
-  // Compute dense size.
+  // Handle strided layouts and shape.
+  std::vector<int64_t> perms(num_dims);
   std::array<iree_hal_dim_t, 9> shape;
   if (num_dims > shape.size()) {
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
@@ -705,11 +687,45 @@ iree_status_t DeviceInstance::HostBufferToDevice(
                             (int)shape.size(), (int)num_dims);
   }
 
+  bool has_zero_length = false;
+  for (int i = 0, s = num_dims; i < s; ++i) {
+    has_zero_length |= dims[i] == 0;
+  }
+
+  if (has_zero_length) {
+    // This is a degenerate case.
+    for (int i = 0; i < num_dims; ++i) {
+      perms[i] = i;
+      shape[i] = dims[i];
+    }
+  } else {
+    // Compute the input shape and permutations for the broadcast.
+    iree::pjrt::computeBroadcastArgs(
+        num_dims, element_type_byte_size, byte_strides, dims,
+        reinterpret_cast<int64_t*>(shape.data()), perms.data());
+  }
+
+  // Splatting requires length 1, 2, or 4
+  bool is_splat = element_type_byte_size == 1 || element_type_byte_size == 2 ||
+                  element_type_byte_size == 4;
+  bool is_dense_row_major = true;
+  for (int i = 0, s = num_dims; i < s; ++i) {
+    is_dense_row_major &= (shape[i] == dims[i]) && (perms[i] == i);
+    is_splat &= (byte_strides[i] == 0) || (dims[i] == 1);
+  }
+
+  if (!is_splat && !is_dense_row_major && !has_zero_length) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "only dense, row-major layouts currently supported");
+  }
+
   iree_device_size_t byte_length = element_type_byte_size;
   for (size_t i = 0; i < num_dims; ++i) {
-    shape[i] = dims[i];
     byte_length *= dims[i];
   }
+
+  byte_length = std::max(element_type_byte_size, byte_length);
 
   iree::vm::ref<iree_hal_buffer_t> buffer;
   // There are multiple ways to implement zero-copy/staged transfers and each
@@ -723,14 +739,18 @@ iree_status_t DeviceInstance::HostBufferToDevice(
   bool require_snapshot_now = host_buffer_semantics ==
                               PJRT_HostBufferSemantics_kImmutableOnlyDuringCall;
   bool caller_data_done = false;
+
+  // We only need a staging buffer if we cannot splat the data.
   iree::vm::ref<iree_hal_buffer_t> host_staging_buffer;
-  IREE_RETURN_IF_ERROR(AcquireHostStagingBuffer(
-      iree_make_const_byte_span(data, byte_length), require_snapshot_now,
-      &caller_data_done, &host_staging_buffer));
-  if (!caller_data_done) {
-    return iree_make_status(
-        IREE_STATUS_UNIMPLEMENTED,
-        "Deferred snapshot of host data not yet implemented");
+  if (!is_splat) {
+    IREE_RETURN_IF_ERROR(AcquireHostStagingBuffer(
+        iree_make_const_byte_span(data, byte_length), require_snapshot_now,
+        &caller_data_done, &host_staging_buffer));
+    if (!caller_data_done) {
+      return iree_make_status(
+          IREE_STATUS_UNIMPLEMENTED,
+          "Deferred snapshot of host data not yet implemented");
+    }
   }
 
   // Allocate on stream. We serialize across 3 timepoints:
@@ -759,25 +779,45 @@ iree_status_t DeviceInstance::HostBufferToDevice(
 
   // Queue up the transfer command.
   iree::vm::ref<iree_hal_command_buffer_t> transfer_cb;
-  iree_hal_transfer_command_t transfer_command;
-  memset(&transfer_command, 0, sizeof(transfer_command));
-  transfer_command.type = IREE_HAL_TRANSFER_COMMAND_TYPE_COPY;
-  transfer_command.copy.source_buffer = host_staging_buffer.get(),
-  transfer_command.copy.source_offset = 0;
-  transfer_command.copy.target_buffer = buffer.get();
-  transfer_command.copy.target_offset = 0;
-  transfer_command.copy.length = byte_length;
-  IREE_RETURN_IF_ERROR(iree_hal_create_transfer_command_buffer(
-      device(), IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
-      IREE_HAL_QUEUE_AFFINITY_ANY,
-      /*transfer_count=*/1, &transfer_command, &transfer_cb));
-  IREE_RETURN_IF_ERROR(iree_hal_device_queue_execute(
-      device(), IREE_HAL_QUEUE_AFFINITY_ANY,
-      /*wait_semaphore_list=*/
-      {1, &transfer_timeline_, &signal_alloca_complete},
-      /*signal_semaphore_list=*/
-      {1, &transfer_timeline_, &signal_copy_complete},
-      /*command_buffer_count=*/1, &transfer_cb));
+  if (is_splat) {
+    IREE_RETURN_IF_ERROR(iree_hal_create_transfer_command_buffer(
+        device(), IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
+        IREE_HAL_QUEUE_AFFINITY_ANY,
+        /*transfer_count=*/0, nullptr, &transfer_cb));
+    IREE_RETURN_IF_ERROR(iree_hal_command_buffer_fill_buffer(
+        transfer_cb.get(), buffer.get(), /*target_offset=*/0,
+        /*target_size=*/byte_length, data, element_type_byte_size));
+  } else if (!has_zero_length) {
+    iree_hal_transfer_command_t transfer_command;
+    memset(&transfer_command, 0, sizeof(transfer_command));
+    transfer_command.type = IREE_HAL_TRANSFER_COMMAND_TYPE_COPY;
+    transfer_command.copy.source_buffer = host_staging_buffer.get(),
+    transfer_command.copy.source_offset = 0;
+    transfer_command.copy.target_buffer = buffer.get();
+    transfer_command.copy.target_offset = 0;
+    transfer_command.copy.length = byte_length;
+    IREE_RETURN_IF_ERROR(iree_hal_create_transfer_command_buffer(
+        device(), IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
+        IREE_HAL_QUEUE_AFFINITY_ANY,
+        /*transfer_count=*/1, &transfer_command, &transfer_cb));
+  }
+
+  if (has_zero_length) {
+    IREE_RETURN_IF_ERROR(iree_hal_device_queue_barrier(
+        device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+        /*wait_semaphore_list=*/
+        {1, &transfer_timeline_, &signal_alloca_complete},
+        /*signal_semaphore_list=*/
+        {1, &transfer_timeline_, &signal_copy_complete}));
+  } else {
+    IREE_RETURN_IF_ERROR(iree_hal_device_queue_execute(
+        device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+        /*wait_semaphore_list=*/
+        {1, &transfer_timeline_, &signal_alloca_complete},
+        /*signal_semaphore_list=*/
+        {1, &transfer_timeline_, &signal_copy_complete},
+        /*command_buffer_count=*/1, &transfer_cb));
+  }
 
   // Wrap in a buffer view and return.
   iree::vm::ref<iree_hal_buffer_view_t> result_buffer_view;

--- a/iree/integrations/pjrt/common/tensor_utils.cc
+++ b/iree/integrations/pjrt/common/tensor_utils.cc
@@ -31,7 +31,8 @@ void computeBroadcastArgs(int64_t ndims, int64_t element_size,
 
   // Populate any unary dimensions to map to their dimension.
   std::vector<int64_t> reverse_perms;
-  reverse_perms.resize(ndims, -1);
+  constexpr int64_t kempty = -1;
+  reverse_perms.resize(ndims, kempty);
   for (int i = 0; i < ndims; ++i) {
     if (output_strides[i] == 0 || output_shape[i] == 1) {
       reverse_perms[i] = i;
@@ -41,7 +42,7 @@ void computeBroadcastArgs(int64_t ndims, int64_t element_size,
   // Populate the reordered dimensions.
   int idx = 0;
   for (int i = 0; i < ndims; i++) {
-    if (reverse_perms[i] == -1) {
+    if (reverse_perms[i] == kempty) {
       reverse_perms[i] = perms[idx];
       idx++;
     }

--- a/iree/integrations/pjrt/common/tensor_utils.cc
+++ b/iree/integrations/pjrt/common/tensor_utils.cc
@@ -1,0 +1,60 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/integrations/pjrt/common/tensor_utils.h"
+
+#include <algorithm>
+#include <vector>
+
+namespace iree {
+namespace pjrt {
+
+void computeBroadcastArgs(int64_t ndims, int64_t element_size,
+                          const int64_t* output_strides,
+                          const int64_t* output_shape, int64_t* input_shape,
+                          int64_t* perms) {
+  // Find all dimensions that have non unary dimensions.
+  int filtered = 0;
+  for (int i = 0; i < ndims; i++) {
+    if (output_strides[i] == 0 || output_shape[i] == 1) continue;
+    perms[filtered] = i;
+    ++filtered;
+  }
+
+  // Solve the order of these dimensions.
+  std::stable_sort(perms, perms + filtered, [&](int64_t a, int64_t b) {
+    return output_strides[a] > output_strides[b];
+  });
+
+  // Populate any unary dimensions to map to their dimension.
+  std::vector<int64_t> reverse_perms;
+  reverse_perms.resize(ndims, -1);
+  for (int i = 0; i < ndims; ++i) {
+    if (output_strides[i] == 0 || output_shape[i] == 1) {
+      reverse_perms[i] = i;
+    }
+  }
+
+  // Populate the reordered dimensions.
+  int idx = 0;
+  for (int i = 0; i < ndims; i++) {
+    if (reverse_perms[i] == -1) {
+      reverse_perms[i] = perms[idx];
+      idx++;
+    }
+  }
+
+  for (int i = 0; i < ndims; i++) {
+    perms[reverse_perms[i]] = i;
+
+    int64_t dim = output_shape[reverse_perms[i]];
+    int64_t stride = output_strides[reverse_perms[i]];
+    input_shape[i] = stride == 0 ? 1 : dim;
+  }
+}
+
+}  // namespace pjrt
+}  // namespace iree

--- a/iree/integrations/pjrt/common/tensor_utils.h
+++ b/iree/integrations/pjrt/common/tensor_utils.h
@@ -1,0 +1,20 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cstdint>
+
+namespace iree {
+namespace pjrt {
+
+// Compute the braodcasting equivalents for an output shape and striding
+// behavior. This cannot guarantee a unique solution but will minimize
+// moving dimensions when possible.
+void computeBroadcastArgs(int64_t ndims, int64_t element_size,
+                          const int64_t* strides, const int64_t* output_shape,
+                          int64_t* input_shape, int64_t* perms);
+
+}  // namespace pjrt
+}  // namespace iree

--- a/iree/integrations/pjrt/common/tensor_utils_test.cc
+++ b/iree/integrations/pjrt/common/tensor_utils_test.cc
@@ -1,0 +1,164 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/integrations/pjrt/common/tensor_utils.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+struct BroadcastTestData {
+  BroadcastTestData(std::vector<int64_t> ishape, std::vector<int64_t> bshape,
+           std::vector<int64_t> perms, int64_t esize = 4) {
+    assert(ishape.size() == bshape.size());
+    assert(ishape.size() == perms.size());
+
+    element_size = esize;
+    input_shape = ishape;
+    broadcast_shape = bshape;
+    permutation = perms;
+
+    output_strides.resize(perms.size());
+    output_shape.resize(perms.size());
+
+    for (int i = 0, s = perms.size(); i < s; ++i) {
+      output_shape[i] = broadcast_shape[perms[i]];
+    }
+
+    std::vector<int64_t> input_strides(ishape.size(), 0);
+    int64_t stride = esize;
+    for (int i = ishape.size() - 1; i >= 0; --i) {
+      if (ishape[i] == 1) continue;
+      input_strides[i] = stride;
+      stride = stride * ishape[i];
+    }
+
+    for (int i = 0, s = perms.size(); i < s; ++i) {
+      output_shape[i] = broadcast_shape[perms[i]];
+    }
+
+    for (int i = 0, s = perms.size(); i < s; ++i) {
+      output_strides[i] = input_strides[perms[i]];
+    }
+  }
+
+  void run_compute() {
+    computed_input_shape.resize(input_shape.size());
+    computed_permutation.resize(input_shape.size());
+
+    iree::pjrt::computeBroadcastArgs(permutation.size(), element_size,
+                                     output_strides.data(), output_shape.data(),
+                                     computed_input_shape.data(),
+                                     computed_permutation.data());
+  }
+
+  int64_t element_size;
+
+  std::vector<int64_t> input_shape;
+  std::vector<int64_t> broadcast_shape;
+  std::vector<int64_t> permutation;
+
+  std::vector<int64_t> output_shape;
+  std::vector<int64_t> output_strides;
+
+  std::vector<int64_t> computed_input_shape;
+  std::vector<int64_t> computed_permutation;
+};
+
+TEST(BroadcastComputeTest, IdentityTest) {
+  struct BroadcastTestData testdata({2, 3, 4}, {2, 3, 4}, {0, 1, 2}, 4);
+
+  ASSERT_THAT(testdata.output_shape, testing::ElementsAre(2, 3, 4));
+  ASSERT_THAT(testdata.output_strides, testing::ElementsAre(48, 16, 4));
+  testdata.run_compute();
+  EXPECT_THAT(testdata.computed_input_shape, testing::ElementsAre(2, 3, 4));
+  EXPECT_THAT(testdata.computed_permutation, testing::ElementsAre(0, 1, 2));
+}
+
+TEST(BroadcastComputeTest, RotateLeftTest) {
+  struct BroadcastTestData testdata({2, 3, 4}, {2, 3, 4}, {1, 2, 0}, 4);
+
+  ASSERT_THAT(testdata.output_shape, testing::ElementsAre(3, 4, 2));
+  ASSERT_THAT(testdata.output_strides, testing::ElementsAre(16, 4, 48));
+  testdata.run_compute();
+  EXPECT_THAT(testdata.computed_input_shape, testing::ElementsAre(2, 3, 4));
+  EXPECT_THAT(testdata.computed_permutation, testing::ElementsAre(1, 2, 0));
+}
+
+TEST(BroadcastComputeTest, RotateRightTest) {
+  struct BroadcastTestData testdata({2, 3, 4}, {2, 3, 4}, {2, 0, 1}, 4);
+
+  ASSERT_THAT(testdata.output_shape, testing::ElementsAre(4, 2, 3));
+  ASSERT_THAT(testdata.output_strides, testing::ElementsAre(4, 48, 16));
+  testdata.run_compute();
+  EXPECT_THAT(testdata.computed_input_shape, testing::ElementsAre(2, 3, 4));
+  EXPECT_THAT(testdata.computed_permutation, testing::ElementsAre(2, 0, 1));
+}
+
+TEST(BroadcastComputeTest, PermutateTest) {
+  struct BroadcastTestData testdata({2, 3, 4}, {2, 3, 4}, {2, 1, 0}, 4);
+
+  ASSERT_THAT(testdata.output_shape, testing::ElementsAre(4, 3, 2));
+  ASSERT_THAT(testdata.output_strides, testing::ElementsAre(4, 16, 48));
+  testdata.run_compute();
+  EXPECT_THAT(testdata.computed_input_shape, testing::ElementsAre(2, 3, 4));
+  EXPECT_THAT(testdata.computed_permutation, testing::ElementsAre(2, 1, 0));
+}
+
+TEST(BroadcastComputeTest, BroadcastFirstTest) {
+  struct BroadcastTestData testdata({1, 3, 4}, {2, 3, 4}, {0, 1, 2}, 4);
+
+  ASSERT_THAT(testdata.output_shape, testing::ElementsAre(2, 3, 4));
+  ASSERT_THAT(testdata.output_strides, testing::ElementsAre(0, 16, 4));
+  testdata.run_compute();
+  EXPECT_THAT(testdata.computed_input_shape, testing::ElementsAre(1, 3, 4));
+  EXPECT_THAT(testdata.computed_permutation, testing::ElementsAre(0, 1, 2));
+}
+
+TEST(BroadcastComputeTest, BroadcastMiddleTest) {
+  struct BroadcastTestData testdata({2, 1, 4}, {2, 3, 4}, {0, 1, 2}, 4);
+
+  ASSERT_THAT(testdata.output_shape, testing::ElementsAre(2, 3, 4));
+  ASSERT_THAT(testdata.output_strides, testing::ElementsAre(16, 0, 4));
+  testdata.run_compute();
+  EXPECT_THAT(testdata.computed_input_shape, testing::ElementsAre(2, 1, 4));
+  EXPECT_THAT(testdata.computed_permutation, testing::ElementsAre(0, 1, 2));
+}
+
+TEST(BroadcastComputeTest, BroadcastLastTest) {
+  struct BroadcastTestData testdata({2, 3, 1}, {2, 3, 4}, {0, 1, 2}, 4);
+
+  ASSERT_THAT(testdata.output_shape, testing::ElementsAre(2, 3, 4));
+  ASSERT_THAT(testdata.output_strides, testing::ElementsAre(12, 4, 0));
+  testdata.run_compute();
+  EXPECT_THAT(testdata.computed_input_shape, testing::ElementsAre(2, 3, 1));
+  EXPECT_THAT(testdata.computed_permutation, testing::ElementsAre(0, 1, 2));
+}
+
+TEST(BroadcastComputeTest, PermutateBroadcastFirstTest) {
+  struct BroadcastTestData testdata({1, 3, 4}, {2, 3, 4}, {0, 2, 1}, 4);
+
+  ASSERT_THAT(testdata.output_shape, testing::ElementsAre(2, 4, 3));
+  ASSERT_THAT(testdata.output_strides, testing::ElementsAre(0, 4, 16));
+  testdata.run_compute();
+  EXPECT_THAT(testdata.computed_input_shape, testing::ElementsAre(1, 3, 4));
+  EXPECT_THAT(testdata.computed_permutation, testing::ElementsAre(0, 2, 1));
+}
+
+TEST(BroadcastComputeTest, PermutateBroadcastMidTest) {
+  struct BroadcastTestData testdata({2, 1, 4}, {2, 3, 4}, {2, 1, 0}, 4);
+
+  testdata.run_compute();
+  EXPECT_THAT(testdata.computed_input_shape, testing::ElementsAre(2, 1, 4));
+  EXPECT_THAT(testdata.computed_permutation, testing::ElementsAre(2, 1, 0));
+}
+
+TEST(BroadcastComputeTest, PermutateBroadcastLastTest) {
+  struct BroadcastTestData testdata({2, 3, 1}, {2, 3, 4}, {1, 0, 2}, 4);
+
+  testdata.run_compute();
+  EXPECT_THAT(testdata.computed_input_shape, testing::ElementsAre(2, 3, 1));
+  EXPECT_THAT(testdata.computed_permutation, testing::ElementsAre(1, 0, 2));
+}

--- a/test/test_degenerate.py
+++ b/test/test_degenerate.py
@@ -1,0 +1,15 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import jax
+
+ones_splat =  jax.numpy.ones((3, 4))
+print(ones_splat)
+
+twos = ones_splat + ones_splat
+print(twos)
+
+ones_degenerate = jax.numpy.ones((4, 0))
+twos_degenerate = ones_degenerate + ones_degenerate
+print(twos_degenerate)


### PR DESCRIPTION
It is possible for the transfer to be degenerate, specifically transferring either a splat matrix or a matrix with a length-0 dimension. This also includes a util for computing the permutation for when permuted examples appear.