### PR TITLE
Update for new PJRT API with new Dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230427.502
-jaxlib==0.4.9.dev20230424
+iree-compiler==20230503.508
+jaxlib==0.4.9.dev20230503
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "6c2f27d83df9214b61a9d2ba2d9b77e54df52520",
-  "xla": "cf0515f724bdbd693b86c5c5b3e01e91eb6ef6be",
-  "jax": "0814b874d50784da22d4af47a54509495f94b8b6"
+  "iree": "0884b3ee6df3946c46d97855d9f78fa9b12b8f90",
+  "xla": "6c6744c8c5ded1c8e4af83296b508e55fe432e19",
+  "jax": "95e1e6d3efff585db5404b2fe5f116027af4acb2"
 }
 
 ORIGINS = {


### PR DESCRIPTION
A recent update to the PJRT API requires an updated implementation. This includes factoring
out DeviceDescription from the DeviceInstance behavior.