### PR TITLE
Added a Jax Test Suite Github actions job

### DIFF
--- a/.github/workflows/run_jaxtests_cpu.yml
+++ b/.github/workflows/run_jaxtests_cpu.yml
@@ -1,0 +1,101 @@
+# Installs prebuilt binaries and runs jax testsuite
+
+name: Run CPU Jax Testsuite
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Do the nightly dep roll at 2:30 PDT.
+    - cron:  '30 21 * * *'
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: run_jax_testsuite_${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+# Jobs are organized into groups and topologically sorted by dependencies
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+
+      - name: "Setting up Python"
+        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
+        with:
+          python-version: "3.10"
+
+      - name: Download last PJRT build
+        id: download-pjrt-build
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build_packages.yml
+          branch: main
+          name: artifact
+
+      - name: Download Last Golden result
+        id: download-last-golden
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: run_jaxtests_cpu.yml
+          branch: main
+          name: artifact
+          if_no_artifact_found: warn
+
+      - name: Sync and install versions
+        run: |
+          # TODO: https://github.com/openxla/openxla-pjrt-plugin/issues/30
+          sudo apt install -y lld
+          # Since only building the runtime, exclude compiler deps (expensive).
+          python ./sync_deps.py --depth 1 --submodules-depth 1 --exclude-submodule "iree:third_party/(llvm|mlir-hlo)"
+          pip install -r requirements.txt
+          python -m pip install absl-py pytest
+          python -m pip install -e ctstools
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v2
+
+      - name: "Configure"
+        run: |
+          python ./configure.py --cc=clang --cxx=clang++
+
+      - name: "Run JAX Testsuite"
+        id: jax-testsuite
+        env:
+          PASSING_ARTIFACT: jaxsuite_passing.txt
+          FAILING_ARTIFACT: jaxsuite_failing.txt
+          GOLDEN_ARTIFACT: jaxsuite_golden.txt
+        run: |
+          source .env.sh
+          echo "testsuite-passing-artifact=${PASSING_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+          echo "testsuite-failing-artifact=${FAILING_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+          echo "testsuite-golden-artifact=${GOLDEN_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+
+          # Ensure the golden file exists.
+          touch ${GOLDEN_ARTIFACT}
+
+          # Point to the downloaded PJRT library.
+          export PJRT_NAMES_AND_LIBRARY_PATHS="iree_cpu:/home/runner/work/openxla-pjrt-plugin/openxla-pjrt-plugin/pjrt_plugins/pjrt_plugin_iree_cpu.so"
+          JAX_PLATFORMS=iree_cpu python test/test_simple.py
+
+          JAX_PLATFORMS=iree_cpu python test/test_jax.py /home/runner/work/openxla-pjrt-plugin/jax/tests/nn_test.py \
+            --passing ${PASSING_ARTIFACT} \
+            --failing ${FAILING_ARTIFACT} \
+            --expected ${GOLDEN_ARTIFACT}
+
+          # If we passed we can update the golden.
+          if [ $? -eq 0 ]; then
+            cp ${PASSING_ARTIFACT} ${GOLDEN_ARTIFACT}
+          fi
+
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: always()
+        with:
+          path: |
+            ${{ steps.jax-testsuite.outputs.testsuite-passing-artifact }}
+            ${{ steps.jax-testsuite.outputs.testsuite-failing-artifact }}
+            ${{ steps.jax-testsuite.outputs.testsuite-golden-artifact }}
+          retention-days: 5

--- a/test/test_jax.py
+++ b/test/test_jax.py
@@ -1,0 +1,132 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import argparse
+import multiprocessing
+import re
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser(prog='test_jax.py',
+                                 description='Run jax testsuite hermetically')
+parser.add_argument('testfiles', nargs="*")
+parser.add_argument('-t', '--timeout', default=20)
+parser.add_argument('-l', '--logdir', default="/tmp/jaxtest")
+parser.add_argument('-p', '--passing', default=None)
+parser.add_argument('-f', '--failing', default=None)
+parser.add_argument('-e', '--expected', default=None)
+
+args = parser.parse_args()
+
+PYTEST_CMD = [
+    "pytest", "-p", "openxla_pjrt_artifacts",
+    f"--openxla-pjrt-artifact-dir={args.logdir}"
+]
+
+
+def get_tests(tests):
+  testlist = []
+  for test in sorted(tests):
+    stdout = subprocess.run(PYTEST_CMD + ["--setup-only", test],
+                            capture_output=True)
+    testlist += re.findall('::[^ ]*::[^ ]*', str(stdout))
+    testlist = [test + func for func in testlist]
+  return testlist
+
+
+def generate_test_commands(tests, timeout=False):
+  cmd = ["timeout", f"{args.timeout}"] if timeout else []
+  cmd += PYTEST_CMD
+  cmds = []
+  for test in tests:
+    test_cmd = cmd + [test]
+    cmds.append(test_cmd)
+
+  return cmds
+
+
+def exec_test(command):
+  result = subprocess.run(command,
+                          stdout=subprocess.DEVNULL,
+                          stderr=subprocess.DEVNULL)
+  sys.stdout.write(".")
+  sys.stdout.flush()
+  return result.returncode
+
+
+def exec_testsuite(commands):
+  returncodes = []
+  with multiprocessing.Pool() as p:
+    returncodes = p.map(exec_test, commands)
+    print("")
+  passing = []
+  failing = []
+  for code, cmd in zip(returncodes, commands):
+    testname = " ".join(cmd)
+    testname = re.search("[^ /]*::[^ ]*::[^ ]*", testname)[0]
+
+    if code == 0:
+      passing.append(testname)
+    else:
+      failing.append(testname)
+  return passing, failing
+
+
+def write_results(filename, results):
+  if (filename is not None):
+    with open(filename, 'w') as f:
+      for line in results:
+        f.write(line + "\n")
+
+
+def load_results(filename):
+  if not filename:
+    return []
+  expected = []
+  with open(filename, 'r') as f:
+    for line in f:
+      expected.append(line.strip())
+  return expected
+
+
+def compare_results(expected, passing):
+  passing = set(passing)
+  expected = set(expected)
+  new_failures = expected - passing
+  new_passing = passing - expected
+  return new_passing, new_failures
+
+
+print("Querying All Tests")
+tests = get_tests(args.testfiles)
+
+print("Generating test suite")
+test_commands = generate_test_commands(tests, timeout=True)
+
+print(f"Executing {len(test_commands)} tests hermetically")
+passing, failing = exec_testsuite(test_commands)
+expected = load_results(args.expected)
+
+write_results(args.passing, passing)
+write_results(args.failing, failing)
+
+print("Total:", len(test_commands))
+print("Passing:", len(passing))
+print("Failing:", len(failing))
+
+if expected:
+  new_passing, new_failures = compare_results(expected, passing)
+
+  if new_passing:
+    print("Newly Passing Tests:")
+    for test in new_passing:
+      print(" ", test)
+
+  if new_failures:
+    print("Newly Failing Tests:")
+    for test in new_failures:
+      print(" ", test)
+
+  if len(expected) > len(passing):
+    exit(1)


### PR DESCRIPTION
Adds a job that executes the JAX test suite using the `iree_cpu` most recent build. This includes an automatic updating system for listing passing tests. For now we only execute on `nn_test.py` for demonstration purposes.