### PR TITLE
Move RunGSPMDPartitionerPass out of anonymous namespace

### DIFF
--- a/partitioner/src/openxla/partitioner/GSPMDPipeline.cpp
+++ b/partitioner/src/openxla/partitioner/GSPMDPipeline.cpp
@@ -136,8 +136,6 @@ void GSPMDOptions::bindOptions(support::OptionsBinder &binder) {
                   llvm::cl::cat(category));
 }
 
-namespace {
-
 class RunGSPMDPartitionerPass
     : public PassWrapper<RunGSPMDPartitionerPass, OperationPass<ModuleOp>> {
  public:
@@ -197,8 +195,6 @@ class RunGSPMDPartitionerPass
 
   GSPMDOptions options;
 };
-
-}  // namespace
 
 // Builds a pipeline which runs the GSPMD partitioner.
 void buildGSPMDPipeline(mlir::PassManager &passManager,


### PR DESCRIPTION
Currently this code fails in debug builds because there is an [explicit debug-only check](https://github.com/llvm/llvm-project/blob/d3b9d8b28f8e9fde41a4136c28f458347d9bb292/mlir/lib/Support/TypeID.cpp#L33) banning TypeID for types in anonymous namespaces.