### PR TITLE
Make RunGSPMDPartitionerPass::getDependentDialects register the diale…

### DIFF
--- a/partitioner/BUILD.bazel
+++ b/partitioner/BUILD.bazel
@@ -85,6 +85,7 @@ cc_library(
         ":defs",
         ":support",
         "@xla//xla/hlo/transforms:hlo_constant_splitter",
+        "@xla//xla/mlir_hlo:hlo_dialect_registration",
         "@xla//xla/mlir_hlo:hlo_legalize_to_stablehlo",
         "@xla//xla/mlir_hlo:mhlo_passes",
         "@xla//xla/mlir_hlo:stablehlo_legalize_to_hlo",

--- a/partitioner/src/openxla/partitioner/GSPMDPipeline.cpp
+++ b/partitioner/src/openxla/partitioner/GSPMDPipeline.cpp
@@ -7,7 +7,11 @@
 #include "openxla/partitioner/GSPMDPipeline.h"
 
 #include "mhlo/transforms/passes.h"
+#include "mhlo/IR/register.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/transforms/hlo_constant_splitter.h"
 #include "xla/service/algebraic_simplifier.h"
@@ -140,6 +144,14 @@ class RunGSPMDPartitionerPass
     : public PassWrapper<RunGSPMDPartitionerPass, OperationPass<ModuleOp>> {
  public:
   RunGSPMDPartitionerPass(GSPMDOptions options) : options(options) {}
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    // HloFunctionImporter needs these
+    registry.insert<arith::ArithDialect>();
+    registry.insert<func::FuncDialect>();
+    mhlo::registerAllMhloDialects(registry);
+    registry.insert<sparse_tensor::SparseTensorDialect>();
+  }
 
  private:
   StringRef getArgument() const override { return "openxla-partitioner-gspmd"; }


### PR DESCRIPTION
…cts used by HloFunctionImporter

Without this, debug builds hit a fatal error here: https://github.com/llvm/llvm-project/blob/2addaeda18adb5a26320693f9b34df8495b8a225/mlir/lib/IR/MLIRContext.cpp#L449
