### PR TITLE
Set allow_spmd_sharding_propagation_to_output to true in the partitioner

### DIFF
--- a/partitioner/src/openxla/partitioner/GSPMDPipeline.cpp
+++ b/partitioner/src/openxla/partitioner/GSPMDPipeline.cpp
@@ -107,9 +107,10 @@ Status RunSPMDOptimizer(HloModule *hlo_module, int64_t num_partitions) {
     spmd_simplify.AddPass<HloDCE>();
 
     spmd_pipeline.AddPass<HloConstantSplitter>();
+    bool allow_spmd_sharding_propagation_to_output[] = { true };
     spmd_pipeline.AddPass<ShardingPropagation>(
         /*is_spmd=*/true, /*propagate_metadata=*/false,
-        hlo_module->config().allow_spmd_sharding_propagation_to_output());
+        absl::MakeSpan(allow_spmd_sharding_propagation_to_output));
     spmd_pipeline.AddPass<spmd::StatefulRngSpmdPartitioner>(
         num_partitions, hlo_module->config().replica_count());
     spmd_pipeline.AddPass<CollectivePermuteMotion>();


### PR DESCRIPTION
Currently `hlo_module->config().allow_spmd_sharding_propagation_to_output()` is always false, because the config created by
`HloModule::CreateModuleConfigFromShape` gets it from the `ExecutionOptions` for which we're passing nullptr.

Seems more useful to make it true. When Jax knows the sharding of the output (e.g. via `jax.jit(output_shardings=...)`), those shardings are emitted in the StableHLO; XLA respects the StableHLO output shardings even with `allow_spmd_sharding_propagation_to_output()` set to true.