### PR TITLE
Pass more compile options to the partitioner

### DIFF
--- a/build_tools/bazel/iree_pjrt.bazelrc
+++ b/build_tools/bazel/iree_pjrt.bazelrc
@@ -23,6 +23,10 @@ build --copt="-fno-exceptions"
 # https://github.com/openxla/xla/issues/1323
 build --nocheck_visibility
 
+# TODO: File issue against XLA team: for deprecations in
+# external/xla/xla/comparison_util.h
+build --copt="-Wno-deprecated-declarations"
+
 ###############################################################################
 # Configurations affecting the build.
 ###############################################################################

--- a/iree/integrations/pjrt/common/BUILD
+++ b/iree/integrations/pjrt/common/BUILD
@@ -59,7 +59,8 @@ iree_pjrt_cc_library(
         "@iree_core//runtime/src/iree/vm/bytecode:module",
         "@xla//xla:shape_util",
         "@xla//xla/pjrt/c:pjrt_c_api_hdrs",
-        "@xla//xla/pjrt:compile_options_proto_cc",
+        # For xla::CompileOptions.
+        "@xla//xla/pjrt:pjrt_executable",
     ],
 )
 

--- a/iree/integrations/pjrt/common/api_impl.h
+++ b/iree/integrations/pjrt/common/api_impl.h
@@ -21,7 +21,7 @@
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode/module.h"
 #include "xla/pjrt/c/pjrt_c_api.h"
-#include "xla/pjrt/compile_options.pb.h"
+#include "xla/pjrt/pjrt_executable.h"
 #include "xla/shape_util.h"
 
 namespace iree::pjrt {
@@ -424,7 +424,7 @@ struct ClientInstance {
 
   // Compiles.
   // See TODOs in PJRT_Client_Compile.
-  PJRT_Error* Compile(PJRT_Program* program, xla::CompileOptionsProto options,
+  PJRT_Error* Compile(PJRT_Program* program, xla::CompileOptions options,
                       LoadedExecutableInstance** executable);
 
   // ---------------------------------------------------------------------------

--- a/partitioner/src/openxla/partitioner/GSPMDPipeline.h
+++ b/partitioner/src/openxla/partitioner/GSPMDPipeline.h
@@ -7,6 +7,7 @@
 #ifndef OPENXLA_PARTITIONER_GSPMD_PIPELINE_H
 #define OPENXLA_PARTITIONER_GSPMD_PIPELINE_H
 
+#include "absl/container/inlined_vector.h"
 #include "mlir/Pass/PassManager.h"
 #include "openxla/partitioner/Support/OptionUtils.h"
 
@@ -15,6 +16,12 @@ namespace openxla::partitioner {
 struct GSPMDOptions {
   // The number of partitions to shard by.
   int numPartitions = 1;
+  // The number of replicas.
+  int replicaCount = 1;
+  // Whether to use SPMD (true) or MPMD (false) when numPartitions > 0.
+  bool useSpmdPartitioning = false;
+  // Allows sharding propagation to propagate to the outputs.
+  absl::InlinedVector<bool, 1> allowSpmdShardingPropagationToOutput = {false};
 
   void bindOptions(support::OptionsBinder &binder);
   using FromFlags = support::OptionsFromFlags<GSPMDOptions>;


### PR DESCRIPTION
Passes `replica_count`, `use_spmd_partitioning`, and `allow_spmd_sharding_propagation_to_output` from the `CompileOptions` received by PJRT to the partitioner.

Fixes #162 